### PR TITLE
Fix compilation on build targets listed below MIPS

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -21260,7 +21260,7 @@ __dll_export
     "ARM"
   #elif defined(__mips64) || defined(__mips64__) || (defined(__mips) && (__mips >= 64))
     "MIPS64"
-  #elif if defined(__mips__) || defined(__mips) || defined(_R4000) || defined(__MIPS__)
+  #elif defined(__mips__) || defined(__mips) || defined(_R4000) || defined(__MIPS__)
     "MIPS"
   #elif defined(__hppa64__) || defined(__HPPA64__) || defined(__hppa64)
     "PARISC64"


### PR DESCRIPTION
A stray `if` causes a syntax error leading to failed compilations on targets listed below the line with MIPS