### PR TITLE
mdbx: fix compilation with devtoolset-9 on CentOS/RHEL 7.

### DIFF
--- a/mdbx.h++
+++ b/mdbx.h++
@@ -286,7 +286,8 @@ class cursor;
 class cursor_managed;
 
 #if defined(DOXYGEN) ||                                                        \
-    defined(__cpp_lib_memory_resource) && __cpp_lib_memory_resource >= 201603L
+    (defined(__cpp_lib_memory_resource) &&                                     \
+     __cpp_lib_memory_resource >= 201603L && _GLIBCXX_USE_CXX11_ABI)
 /// \brief Default polymorphic allocator for modern code.
 using polymorphic_allocator = ::std::pmr::string::allocator_type;
 #endif /* __cpp_lib_memory_resource >= 201603L */

--- a/src/mdbx.c++
+++ b/src/mdbx.c++
@@ -992,7 +992,8 @@ bool from_base64::is_erroneous() const noexcept {
 
 template class LIBMDBX_API_TYPE buffer<legacy_allocator>;
 
-#if defined(__cpp_lib_memory_resource) && __cpp_lib_memory_resource >= 201603L
+#if defined(__cpp_lib_memory_resource) &&                                      \
+    __cpp_lib_memory_resource >= 201603L && _GLIBCXX_USE_CXX11_ABI
 template class LIBMDBX_API_TYPE buffer<polymorphic_allocator>;
 #endif /* __cpp_lib_memory_resource >= 201603L */
 


### PR DESCRIPTION
devtoolset is always using the old ABI
https://bugzilla.redhat.com/show_bug.cgi?id=1546704
https://stackoverflow.com/questions/49393888/how-can-i-use-the-new-c-11-abi-with-devtoolset-7-on-centos-rhel