### PR TITLE
MDBX_SET_UPPERBOUND

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.[ao]
+*.err
+*.log
 *.bak
 *.exe
 *.gcda

--- a/mdbx.h
+++ b/mdbx.h
@@ -1583,7 +1583,12 @@ enum MDBX_cursor_op {
    * i.e. for a pairs/tuples of a key and an each data value of duplicates.
    * Returns \ref MDBX_SUCCESS if key-value pair found exactly and
    * \ref MDBX_RESULT_TRUE if the next pair was returned. */
-  MDBX_SET_LOWERBOUND
+  MDBX_SET_LOWERBOUND,
+
+  /** Position at first key-value pair lesser than or equal to specified, 
+   * return same as MDBX_SET_LOWERBOUND 
+  */
+  MDBX_SET_UPPERBOUND
 };
 #ifndef __cplusplus
 /** \ingroup c_cursors */


### PR DESCRIPTION
add MDBX_SET_UPPERBOUND

see issue https://github.com/erthink/libmdbx/issues/250

When the value is mdbx_val_empty(), the test result should be correct (the screenshot of [the running result of my rust code ](https://github.com/rmw-lib/mdbx/blob/172030796f21851a594ff69c44b3fb9d1be35511/examples/main.rs) is as below).
![](https://user-images.githubusercontent.com/69608605/145676784-9f871334-9dd7-4975-b886-1984bdf0058a.png)
If there is a certain value, I am not sure whether the logic is correct, because I have not used this and I have not fully understood the code of MDBX_SET_LOWERBOUND, so please help me fix it.
