### PR TITLE
Add move assignment operator for cursor_managed

### DIFF
--- a/mdbx.h++
+++ b/mdbx.h++
@@ -3939,7 +3939,12 @@ public:
   void close();
 
   cursor_managed(cursor_managed &&) = default;
-  cursor_managed &operator=(cursor_managed &&) = default;
+  cursor_managed &operator=(cursor_managed && other) noexcept {
+    ::mdbx_cursor_close(handle_);
+    handle_ = other.handle_;
+    other.handle_ = nullptr;
+    return *this;
+  }
   cursor_managed(const cursor_managed &) = delete;
   cursor_managed &operator=(const cursor_managed &) = delete;
   ~cursor_managed() noexcept { ::mdbx_cursor_close(handle_); }


### PR DESCRIPTION
Custom move assignment operator for `cursor_managed` is required to close the current handle before moving (see also https://github.com/torquem-ch/silkworm/issues/575).