### PR TITLE
mdbx: fix missing return on NtUnmapViewOfSection failure in osal_munmap()

### DIFF
--- a/mdbx.c
+++ b/mdbx.c
@@ -30088,7 +30088,7 @@ int osal_munmap(osal_mmap_t *map) {
     NtClose(map->section);
   NTSTATUS rc = NtUnmapViewOfSection(GetCurrentProcess(), map->base);
   if (!NT_SUCCESS(rc))
-    osal_ntstatus2errcode(rc);
+    return osal_ntstatus2errcode(rc);
 #else
   if (unlikely(munmap(map->base, map->limit))) {
     assert(errno != 0);


### PR DESCRIPTION
The error path computed the status via osal_ntstatus2errcode() but did not return it, so callers could incorrectly observe MDBX_SUCCESS.